### PR TITLE
fix: support fuse-t on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,15 +112,16 @@ Built for Neovim 0.10+ using the best of both `sshfs` and `ssh` in tandem with y
 
 ### 🍏 macOS Setup
 
-To use **sshfs.nvim** on macOS, follow these steps:
+sshfs.nvim supports both **macFUSE** and the kextless **fuse-t** implementation.
 
-1. **Install macFUSE**
-   Download and install macFUSE from the official site:
-   [https://macfuse.github.io/](https://macfuse.github.io/)
+#### macFUSE
 
-2. **Install SSHFS for macFUSE**
-   Use the official SSHFS releases compatible with macFUSE:
-   [https://github.com/macfuse/macfuse/wiki/File-Systems-%E2%80%90-SSHFS](https://github.com/macfuse/macfuse/wiki/File-Systems-%E2%80%90-SSHFS)
+1. Install macFUSE from [macfuse.github.io](https://macfuse.github.io/).
+2. Install an SSHFS release compatible with macFUSE from the [macFUSE SSHFS documentation](https://github.com/macfuse/macfuse/wiki/File-Systems-%E2%80%90-SSHFS).
+
+#### fuse-t
+
+Install `fuse-t` and `fuse-t-sshfs` from the [`macos-fuse-t/homebrew-cask`](https://github.com/macos-fuse-t/homebrew-cask) tap. fuse-t exposes SSHFS mounts through its NFS backend and currently ships an SSHFS 2.9-compatible implementation; sshfs.nvim detects these mounts and translates its directory-cache option names automatically.
 
 ## 📦 Installation
 

--- a/lua/sshfs/api.lua
+++ b/lua/sshfs/api.lua
@@ -218,6 +218,14 @@ Api.live_grep = function(path)
   end
 
   local function execute_live_grep(connection)
+    if connection.remote_metadata_available == false then
+      vim.notify(
+        "Remote host/path metadata is unavailable for this mount. Falling back to local grep on the mounted path.",
+        vim.log.levels.WARN
+      )
+      return fallback_to_local_grep(connection)
+    end
+
     local Picker = require("sshfs.ui.picker")
     local config = Config.get()
     local search_path = connection.remote_path or path or "."
@@ -275,6 +283,14 @@ Api.live_find = function(path)
   end
 
   local function execute_live_find(connection)
+    if connection.remote_metadata_available == false then
+      vim.notify(
+        "Remote host/path metadata is unavailable for this mount. Falling back to the mounted path.",
+        vim.log.levels.WARN
+      )
+      return fallback_to_local_find(connection)
+    end
+
     local Picker = require("sshfs.ui.picker")
     local config = Config.get()
     local search_path = connection.remote_path or path or "."

--- a/lua/sshfs/init.lua
+++ b/lua/sshfs/init.lua
@@ -48,11 +48,11 @@ function App.setup(user_opts)
     desc = "Register in lockfile when accessing SSHFS mount",
   })
 
-  -- Setup exit handler if enabled
+  -- Setup exit handler if enabled. VimLeavePre keeps the event loop available while mounts are unmounted.
   local hooks = opts.hooks or {}
   local on_exit = hooks.on_exit or {}
   if on_exit.auto_unmount then
-    vim.api.nvim_create_autocmd("VimLeave", {
+    vim.api.nvim_create_autocmd("VimLeavePre", {
       callback = function()
         local Session = require("sshfs.session")
         Session.cleanup_unused_mounts()

--- a/lua/sshfs/lib/mount_point.lua
+++ b/lua/sshfs/lib/mount_point.lua
@@ -6,7 +6,7 @@ local Directory = require("sshfs.lib.directory")
 local Config = require("sshfs.config")
 
 --- Get all active SSHFS mount paths and remote info from the system
---- @return table Array of mount info tables with {mount_path, remote_spec} where remote_spec is "user@host:/path" or "host:/path"
+--- @return table Array of mount info tables with {mount_path, remote_spec} where remote_spec may be nil when unavailable
 local function get_system_mounts()
   local mounts = {}
 
@@ -38,9 +38,13 @@ local function get_system_mounts()
     "^(%S+)%s+on%s+([^%s]+)%s+%(fuse", -- Generic FUSE: "user@host:/path on /mount/path (fuse"
   }
 
-  -- Only process lines that contain 'sshfs' to avoid false positives
+  -- Only process SSHFS-compatible mount lines to avoid false positives
   for line in result:gmatch("[^\r\n]+") do
-    if line:match("sshfs") or line:match("macfuse") then
+    -- fuse-t presents SSHFS mounts as NFS and does not expose the original remote spec.
+    local fuse_t_mount = line:match("^fuse%-t:%S+%s+on%s+([^%s]+)%s+%(nfs")
+    if fuse_t_mount then
+      table.insert(mounts, { mount_path = fuse_t_mount, remote_spec = nil })
+    elseif line:match("sshfs") or line:match("macfuse") then
       for _, pattern in ipairs(pattern_templates) do
         local remote_spec, mount_path = line:match(pattern)
         if remote_spec and mount_path then
@@ -70,7 +74,7 @@ function MountPoint.is_active(mount_path)
 end
 
 --- List all active sshfs mounts
---- @return table Array of mount objects with host, mount_path, and remote_path fields
+--- @return table Array of mount objects with host, mount_path, remote_path, and remote_metadata_available fields
 function MountPoint.list_active()
   local mounts = {}
   local base_mount_dir = Config.get_base_dir()
@@ -83,15 +87,20 @@ function MountPoint.list_active()
   for _, mount_info in ipairs(system_mounts) do
     local mount_name = mount_info.mount_path:match(prefix_pattern)
     if mount_name and mount_name ~= "" then
-      -- Parse remote_spec to extract actual SSH hostname and remote path
-      -- Format: "user@host:/remote/path" or "host:/remote/path"
-      local remote_path = mount_info.remote_spec:match(":(.*)$")
-      local host = mount_info.remote_spec:match("@([^:]+):") or mount_info.remote_spec:match("^([^:]+):")
+      -- Parse remote_spec to extract actual SSH hostname and remote path when available.
+      -- fuse-t mount output does not expose this metadata; mount_name remains display-only fallback metadata.
+      local remote_spec = mount_info.remote_spec
+      local remote_path = remote_spec and remote_spec:match(":(.*)$") or nil
+      local host = remote_spec
+          and (remote_spec:match("@([^:]+):") or remote_spec:match("^([^:]+):"))
+        or nil
+      local remote_metadata_available = host ~= nil and remote_path ~= nil
 
       table.insert(mounts, {
-        host = host or mount_name, -- Fall back to mount dir name if parsing fails
+        host = host or mount_name,
         mount_path = mount_info.mount_path,
-        remote_path = remote_path or "/", -- Default to root if parsing fails
+        remote_path = remote_path,
+        remote_metadata_available = remote_metadata_available,
       })
     end
   end
@@ -117,7 +126,7 @@ function MountPoint.has_active()
 end
 
 --- Get first active mount (for backward compatibility with single-mount workflows)
---- @return table|nil Mount object with host, mount_path, and remote_path fields, or nil if none
+--- @return table|nil Mount object with host, mount_path, remote_path, and remote_metadata_available fields, or nil if none
 function MountPoint.get_active()
   local mounts = MountPoint.list_active()
   if #mounts > 0 then return mounts[1] end
@@ -190,7 +199,7 @@ function MountPoint.release_mount(mount_path, is_q_exit)
   return true
 end
 
---- Unmount an sshfs mount using fusermount/umount
+--- Unmount an sshfs mount synchronously using fusermount/umount/diskutil
 --- @param mount_path string Path to unmount
 --- @return boolean True if unmount succeeded
 function MountPoint.unmount(mount_path)
@@ -212,19 +221,9 @@ function MountPoint.unmount(mount_path)
   for _, cmd in ipairs(commands) do
     local command, args = cmd[1], cmd[2]
 
-    -- Try command if executable with jobstart
     if vim.fn.executable(command) == 1 then
-      local job_id = vim.fn.jobstart(vim.list_extend({ command }, args), {
-        stdout_buffered = true,
-        stderr_buffered = true,
-      })
-      local exit_code = -1
-      if job_id > 0 then
-        local result = vim.fn.jobwait({ job_id }, 5000)[1] -- 5 second timeout
-        exit_code = result or -1
-      end
-
-      if exit_code == 0 then
+      local result = vim.system(vim.list_extend({ command }, args), { text = true }):wait(5000)
+      if result.code == 0 then
         vim.fn.delete(mount_path, "d")
         return true
       end

--- a/lua/sshfs/lib/mount_point.lua
+++ b/lua/sshfs/lib/mount_point.lua
@@ -91,9 +91,7 @@ function MountPoint.list_active()
       -- fuse-t mount output does not expose this metadata; mount_name remains display-only fallback metadata.
       local remote_spec = mount_info.remote_spec
       local remote_path = remote_spec and remote_spec:match(":(.*)$") or nil
-      local host = remote_spec
-          and (remote_spec:match("@([^:]+):") or remote_spec:match("^([^:]+):"))
-        or nil
+      local host = remote_spec and (remote_spec:match("@([^:]+):") or remote_spec:match("^([^:]+):")) or nil
       local remote_metadata_available = host ~= nil and remote_path ~= nil
 
       table.insert(mounts, {

--- a/lua/sshfs/lib/mount_point.lua
+++ b/lua/sshfs/lib/mount_point.lua
@@ -10,15 +10,23 @@ local Config = require("sshfs.config")
 local function get_system_mounts()
   local mounts = {}
 
-  -- Try findmnt first (Linux only) if available - it can show both SOURCE and TARGET
+  -- Try findmnt first (Linux only) if available - it can show both SOURCE and TARGET.
+  -- fuse-t presents SSHFS mounts as NFS, so both filesystem types are queried and
+  -- FSTYPE is requested before TARGET to keep the target as the greedy trailing field.
   if vim.fn.executable("findmnt") == 1 then
-    local findmnt_result = vim.fn.system({ "findmnt", "-t", "fuse.sshfs", "-n", "-o", "SOURCE,TARGET" })
+    local findmnt_result = vim.fn.system({ "findmnt", "-t", "fuse.sshfs,nfs", "-n", "-o", "SOURCE,FSTYPE,TARGET" })
     if vim.v.shell_error == 0 then
       for line in findmnt_result:gmatch("[^\r\n]+") do
-        -- findmnt output: "user@host:/remote/path /local/mount"
-        local remote_spec, mount_path = line:match("^(%S+)%s+(.+)$")
-        if remote_spec and mount_path then
-          table.insert(mounts, { mount_path = mount_path, remote_spec = remote_spec })
+        -- findmnt output: "user@host:/remote/path fuse.sshfs /local/mount"
+        local source, fstype, mount_path = line:match("^(%S+)%s+(%S+)%s+(.+)$")
+        if source and fstype and mount_path then
+          if source:match("^fuse%-t:") then
+            -- fuse-t does not expose the original remote spec.
+            table.insert(mounts, { mount_path = mount_path, remote_spec = nil })
+          elseif fstype == "fuse.sshfs" then
+            table.insert(mounts, { mount_path = mount_path, remote_spec = source })
+          end
+          -- Any other NFS mount is unrelated to SSHFS and is skipped.
         end
       end
       return mounts

--- a/lua/sshfs/lib/sshfs.lua
+++ b/lua/sshfs/lib/sshfs.lua
@@ -2,6 +2,65 @@
 -- SSHFS wrapper with authentication workflows
 
 local Sshfs = {}
+local sshfs_major_version
+local sshfs_version_warning_shown = false
+
+--- Detect the installed SSHFS major version once per Neovim instance.
+--- @return number|nil Major version, or nil if it cannot be determined
+local function get_sshfs_major_version()
+  if sshfs_major_version ~= nil then return sshfs_major_version or nil end
+
+  local ok, process = pcall(vim.system, { "sshfs", "--version" }, { text = true })
+  if ok then
+    local result = process:wait()
+    if result.code == 0 then
+      local output = (result.stdout or "") .. "\n" .. (result.stderr or "")
+      sshfs_major_version =
+        tonumber(output:match("SSHFS version%s+(%d+)") or output:match("SSHFS%s+(%d+)")) or false
+    else
+      sshfs_major_version = false
+    end
+  else
+    sshfs_major_version = false
+  end
+
+  if not sshfs_major_version and not sshfs_version_warning_shown then
+    sshfs_version_warning_shown = true
+    vim.notify(
+      "Unable to detect SSHFS version; using configured option names unchanged. SSHFS 2.x/fuse-t may require cache, cache_timeout, and cache_max_size.",
+      vim.log.levels.WARN
+    )
+  end
+
+  return sshfs_major_version or nil
+end
+
+--- Translate sshfs 3.x directory-cache option names for sshfs 2.x implementations.
+--- Explicit 2.x options take precedence over translated defaults/user values.
+--- @param options_table table
+--- @return table
+local function normalize_sshfs_options(options_table)
+  local options = vim.deepcopy(options_table)
+  local major = get_sshfs_major_version()
+  if not major or major >= 3 then return options end
+
+  if options.dir_cache ~= nil then
+    if options.cache == nil then options.cache = options.dir_cache end
+    options.dir_cache = nil
+  end
+
+  if options.dcache_timeout ~= nil then
+    if options.cache_timeout == nil then options.cache_timeout = options.dcache_timeout end
+    options.dcache_timeout = nil
+  end
+
+  if options.dcache_max_size ~= nil then
+    if options.cache_max_size == nil then options.cache_max_size = options.dcache_max_size end
+    options.dcache_max_size = nil
+  end
+
+  return options
+end
 
 --- Convert sshfs_options table to array format for sshfs -o
 --- @param options_table table Table of options (e.g., {reconnect = true, ConnectTimeout = 5})
@@ -34,7 +93,7 @@ local function get_sshfs_options(auth_type)
 
   -- Add user-configured sshfs options from config (convert table to array)
   if opts.connections and opts.connections.sshfs_options then
-    local sshfs_opts = build_sshfs_args(opts.connections.sshfs_options)
+    local sshfs_opts = build_sshfs_args(normalize_sshfs_options(opts.connections.sshfs_options))
     vim.list_extend(options, sshfs_opts)
   end
 

--- a/lua/sshfs/lib/sshfs.lua
+++ b/lua/sshfs/lib/sshfs.lua
@@ -10,18 +10,18 @@ local sshfs_version_warning_shown = false
 local function get_sshfs_major_version()
   if sshfs_major_version ~= nil then return sshfs_major_version or nil end
 
+  sshfs_major_version = false
+
+  -- Bounded wait: a hung `sshfs --version` must not block Neovim indefinitely.
   local ok, process = pcall(vim.system, { "sshfs", "--version" }, { text = true })
   if ok then
-    local result = process:wait()
-    if result.code == 0 then
+    local wait_ok, result = pcall(process.wait, process, 2000)
+    if wait_ok and result then
+      -- Some builds report the version on stderr and/or exit non-zero, so parse
+      -- whatever output is available rather than gating on the exit code.
       local output = (result.stdout or "") .. "\n" .. (result.stderr or "")
-      sshfs_major_version =
-        tonumber(output:match("SSHFS version%s+(%d+)") or output:match("SSHFS%s+(%d+)")) or false
-    else
-      sshfs_major_version = false
+      sshfs_major_version = tonumber(output:match("SSHFS version%s+(%d+)") or output:match("SSHFS%s+(%d+)")) or false
     end
-  else
-    sshfs_major_version = false
   end
 
   if not sshfs_major_version and not sshfs_version_warning_shown then

--- a/lua/sshfs/ui/hooks.lua
+++ b/lua/sshfs/ui/hooks.lua
@@ -74,6 +74,14 @@ local function run_preset_action(preset, mount_dir, config)
       )
       return run_preset_action(preset == "live_grep" and "grep" or "find", mount_dir, config)
     end
+    if conn.remote_metadata_available == false then
+      vim.notify(
+        "Remote host/path metadata is unavailable for this mount – falling back to local "
+          .. (preset == "live_grep" and "grep" or "find"),
+        vim.log.levels.WARN
+      )
+      return run_preset_action(preset == "live_grep" and "grep" or "find", mount_dir, config)
+    end
     local Picker = require("sshfs.ui.picker")
     local fn = preset == "live_grep" and Picker.open_live_remote_grep or Picker.open_live_remote_find
     local ok, picker_name = fn(conn.host, conn.mount_path, conn.remote_path or ".", config)

--- a/lua/sshfs/ui/terminal.lua
+++ b/lua/sshfs/ui/terminal.lua
@@ -3,10 +3,22 @@
 
 local Terminal = {}
 
+local function open_connection_terminal(connection)
+  if connection.remote_metadata_available == false then
+    vim.notify(
+      "Remote host metadata is unavailable for this mount; cannot open an SSH terminal.",
+      vim.log.levels.WARN
+    )
+    return
+  end
+
+  local Ssh = require("sshfs.lib.ssh")
+  Ssh.open_terminal(connection.host, connection.remote_path)
+end
+
 --- Open SSH terminal session to remote host
 function Terminal.open_ssh()
   local MountPoint = require("sshfs.lib.mount_point")
-  local Ssh = require("sshfs.lib.ssh")
   local active_connections = MountPoint.list_active()
 
   if #active_connections == 0 then
@@ -15,8 +27,7 @@ function Terminal.open_ssh()
   end
 
   if #active_connections == 1 then
-    local conn = active_connections[1]
-    Ssh.open_terminal(conn.host, conn.remote_path)
+    open_connection_terminal(active_connections[1])
     return
   end
 
@@ -28,10 +39,7 @@ function Terminal.open_ssh()
   vim.ui.select(items, {
     prompt = "Select host for SSH terminal:",
   }, function(_, idx)
-    if idx then
-      local conn = active_connections[idx]
-      Ssh.open_terminal(conn.host, conn.remote_path)
-    end
+    if idx then open_connection_terminal(active_connections[idx]) end
   end)
 end
 

--- a/lua/sshfs/ui/terminal.lua
+++ b/lua/sshfs/ui/terminal.lua
@@ -5,10 +5,7 @@ local Terminal = {}
 
 local function open_connection_terminal(connection)
   if connection.remote_metadata_available == false then
-    vim.notify(
-      "Remote host metadata is unavailable for this mount; cannot open an SSH terminal.",
-      vim.log.levels.WARN
-    )
+    vim.notify("Remote host metadata is unavailable for this mount; cannot open an SSH terminal.", vim.log.levels.WARN)
     return
   end
 

--- a/tests/fuse_t_spec.lua
+++ b/tests/fuse_t_spec.lua
@@ -1,0 +1,114 @@
+-- tests/fuse_t_spec.lua
+-- Regression coverage for fuse-t compatibility on macOS
+--
+-- fuse-t exposes SSHFS mounts through NFS, so the mount table carries no
+-- remote spec and the installed sshfs is a 2.x implementation with different
+-- directory-cache option names.
+
+local BASE_DIR = "/Users/tester/mnt"
+
+local FUSE_T_MOUNT = "fuse-t:/sshfs_nvim_mount on " .. BASE_DIR .. "/host (nfs, nodev, nosuid, mounted by tester)"
+
+--- Load MountPoint against a stubbed mount table
+--- @param opts table {mount_output, findmnt_output, findmnt_available}
+local function with_mounts(opts)
+  stub.reload()
+  require("sshfs.config").setup({ mounts = { base_dir = BASE_DIR } })
+
+  stub.executable({ findmnt = opts.findmnt_available or false })
+  stub.system(function(cmd)
+    if type(cmd) == "table" and cmd[1] == "findmnt" then return opts.findmnt_output or "", opts.findmnt_code or 0 end
+    return opts.mount_output or "", 0
+  end)
+
+  return require("sshfs.lib.mount_point")
+end
+
+describe("fuse-t mount detection", function()
+  it("parses a fuse-t NFS-backed mount line", function()
+    local MountPoint = with_mounts({ mount_output = FUSE_T_MOUNT })
+
+    local mounts = MountPoint.list_active()
+    expect.eq(#mounts, 1)
+    expect.eq(mounts[1].mount_path, BASE_DIR .. "/host")
+    stub.restore_all()
+  end)
+
+  it("reports fuse-t mounts as lacking remote metadata", function()
+    local MountPoint = with_mounts({ mount_output = FUSE_T_MOUNT })
+
+    local mount = MountPoint.list_active()[1]
+    expect.eq(mount.remote_metadata_available, false)
+    stub.restore_all()
+  end)
+
+  it("does not invent an authoritative remote path", function()
+    local MountPoint = with_mounts({ mount_output = FUSE_T_MOUNT })
+
+    local mount = MountPoint.list_active()[1]
+    expect.is_nil(mount.remote_path, "an unknown remote path must stay unknown, not default to /")
+    stub.restore_all()
+  end)
+
+  it("falls back to the mount directory name for display", function()
+    local MountPoint = with_mounts({ mount_output = FUSE_T_MOUNT })
+
+    local mount = MountPoint.list_active()[1]
+    expect.eq(mount.host, "host")
+    expect.eq(MountPoint.format_label(mount), "host", "no remote path means no path suffix in the label")
+    stub.restore_all()
+  end)
+
+  it("does not error on a mount without a remote spec", function()
+    local MountPoint = with_mounts({ mount_output = FUSE_T_MOUNT })
+
+    expect.no_error(function()
+      MountPoint.list_active()
+    end)
+    stub.restore_all()
+  end)
+
+  it("detects fuse-t mounts through findmnt as well as mount", function()
+    local MountPoint = with_mounts({
+      findmnt_available = true,
+      findmnt_output = "fuse-t:/sshfs_nvim_mount nfs " .. BASE_DIR .. "/host\n",
+    })
+
+    local mounts = MountPoint.list_active()
+    expect.eq(#mounts, 1, "findmnt must not short-circuit past fuse-t mounts")
+    expect.eq(mounts[1].mount_path, BASE_DIR .. "/host")
+    expect.eq(mounts[1].remote_metadata_available, false)
+    stub.restore_all()
+  end)
+
+  it("keeps unrelated NFS mounts out of the results", function()
+    local MountPoint = with_mounts({
+      findmnt_available = true,
+      findmnt_output = table.concat({
+        "nfsserver:/export nfs " .. BASE_DIR .. "/company-share",
+        "fuse-t:/sshfs_nvim_mount nfs " .. BASE_DIR .. "/host",
+      }, "\n"),
+    })
+
+    local mounts = MountPoint.list_active()
+    expect.eq(#mounts, 1, "a real NFS mount under the base directory is not an SSHFS mount")
+    expect.eq(mounts[1].mount_path, BASE_DIR .. "/host")
+    stub.restore_all()
+  end)
+
+  it("still reports remote metadata for a real sshfs mount alongside fuse-t", function()
+    local MountPoint = with_mounts({
+      mount_output = table.concat({
+        FUSE_T_MOUNT,
+        "deploy@example.com:/srv/app on " .. BASE_DIR .. "/example type fuse.sshfs (rw)",
+      }, "\n"),
+    })
+
+    local mounts = MountPoint.list_active()
+    expect.eq(#mounts, 2)
+    expect.eq(mounts[1].remote_metadata_available, false)
+    expect.eq(mounts[2].remote_metadata_available, true)
+    expect.eq(mounts[2].remote_path, "/srv/app")
+    stub.restore_all()
+  end)
+end)

--- a/tests/metadata_fallback_spec.lua
+++ b/tests/metadata_fallback_spec.lua
@@ -1,0 +1,185 @@
+-- tests/metadata_fallback_spec.lua
+-- Behavior when a mount exposes no remote host/path metadata (fuse-t)
+--
+-- Operations with a mounted-filesystem equivalent fall back to the mount path.
+-- Operations that genuinely need a remote host refuse instead of guessing.
+
+local MOUNT_PATH = "/Users/tester/mnt/host"
+
+--- Record which picker entry points get called
+--- @return table calls
+local function fake_picker()
+  local calls = {}
+  package.loaded["sshfs.ui.picker"] = {
+    open_live_remote_grep = function()
+      table.insert(calls, "live_grep")
+      return true, "telescope"
+    end,
+    open_live_remote_find = function()
+      table.insert(calls, "live_find")
+      return true, "telescope"
+    end,
+    grep_remote_files = function()
+      table.insert(calls, "local_grep")
+    end,
+    open_file_picker = function()
+      table.insert(calls, "local_find")
+      return true, "telescope"
+    end,
+  }
+  return calls
+end
+
+--- Present a single active mount to the modules under test
+--- @param mount table Mount object returned by MountPoint.list_active
+local function fake_single_mount(mount)
+  package.loaded["sshfs.lib.mount_point"] = {
+    list_active = function()
+      return { mount }
+    end,
+    get_active = function()
+      return mount
+    end,
+    has_active = function()
+      return true
+    end,
+  }
+end
+
+local FUSE_T_MOUNT = {
+  host = "host",
+  mount_path = MOUNT_PATH,
+  remote_path = nil,
+  remote_metadata_available = false,
+}
+
+local SSHFS_MOUNT = {
+  host = "example.com",
+  mount_path = MOUNT_PATH,
+  remote_path = "/srv/app",
+  remote_metadata_available = true,
+}
+
+local function setup(mount)
+  stub.reload()
+  require("sshfs.config").setup({})
+  fake_single_mount(mount)
+  local calls = fake_picker()
+  local notifications = stub.notifications()
+  return calls, notifications
+end
+
+describe("live grep without remote metadata", function()
+  it("falls back to grepping the mounted path", function()
+    local calls, notifications = setup(FUSE_T_MOUNT)
+
+    require("sshfs.api").live_grep()
+    stub.restore_all()
+
+    expect.eq(calls, { "local_grep" }, "remote grep needs a real host and must not be attempted")
+    expect.contains(notifications[1].message, "metadata is unavailable")
+  end)
+
+  it("still greps remotely when metadata is available", function()
+    local calls = setup(SSHFS_MOUNT)
+
+    require("sshfs.api").live_grep()
+    stub.restore_all()
+
+    expect.eq(calls, { "live_grep" })
+  end)
+end)
+
+describe("live find without remote metadata", function()
+  it("falls back to the mounted path", function()
+    local calls, notifications = setup(FUSE_T_MOUNT)
+
+    require("sshfs.api").live_find()
+    stub.restore_all()
+
+    expect.eq(calls, { "local_find" })
+    expect.contains(notifications[1].message, "metadata is unavailable")
+  end)
+
+  it("still finds remotely when metadata is available", function()
+    local calls = setup(SSHFS_MOUNT)
+
+    require("sshfs.api").live_find()
+    stub.restore_all()
+
+    expect.eq(calls, { "live_find" })
+  end)
+end)
+
+describe("on_mount auto_run without remote metadata", function()
+  --- Run the post-mount hook for a preset against a given mount
+  local function run_auto_run(mount, auto_run)
+    local calls, notifications = setup(mount)
+    stub.set("cmd", function() end)
+
+    require("sshfs.ui.hooks").on_mount(mount.mount_path, mount.host, mount.remote_path, {
+      hooks = { on_mount = { auto_run = auto_run, auto_change_to_dir = false } },
+    })
+    stub.restore_all()
+
+    return calls, notifications
+  end
+
+  it("falls back to local grep for live_grep", function()
+    local calls, notifications = run_auto_run(FUSE_T_MOUNT, "live_grep")
+
+    expect.eq(calls, { "local_grep" })
+    expect.contains(notifications[1].message, "metadata is unavailable")
+  end)
+
+  it("falls back to local find for live_find", function()
+    local calls, notifications = run_auto_run(FUSE_T_MOUNT, "live_find")
+
+    expect.eq(calls, { "local_find" })
+    expect.contains(notifications[1].message, "metadata is unavailable")
+  end)
+
+  it("runs the remote action when metadata is available", function()
+    local calls = run_auto_run(SSHFS_MOUNT, "live_grep")
+    expect.eq(calls, { "live_grep" })
+  end)
+end)
+
+describe("SSH terminal without remote metadata", function()
+  --- @return table opened Hosts an SSH terminal was opened for
+  --- @return table notifications Captured vim.notify calls
+  local function open_terminal_for(mount)
+    stub.reload()
+    require("sshfs.config").setup({})
+    fake_single_mount(mount)
+
+    local opened = {}
+    package.loaded["sshfs.lib.ssh"] = {
+      open_terminal = function(host, remote_path)
+        table.insert(opened, { host = host, remote_path = remote_path })
+      end,
+    }
+    local notifications = stub.notifications()
+
+    require("sshfs.ui.terminal").open_ssh()
+    stub.restore_all()
+
+    return opened, notifications
+  end
+
+  it("refuses cleanly instead of using the display-only fallback host", function()
+    local opened, notifications = open_terminal_for(FUSE_T_MOUNT)
+
+    expect.eq(opened, {}, "the mount directory name is not a routable SSH host")
+    expect.eq(#notifications, 1)
+    expect.contains(notifications[1].message, "metadata is unavailable")
+  end)
+
+  it("opens a terminal when the remote host is known", function()
+    local opened = open_terminal_for(SSHFS_MOUNT)
+
+    expect.eq(#opened, 1)
+    expect.eq(opened[1].host, "example.com")
+    expect.eq(opened[1].remote_path, "/srv/app")
+  end)
+end)

--- a/tests/mount_point_spec.lua
+++ b/tests/mount_point_spec.lua
@@ -32,6 +32,7 @@ describe("MountPoint.list_active", function()
         host = "example.com",
         mount_path = BASE_DIR .. "/example",
         remote_path = "/srv/app",
+        remote_metadata_available = true,
       },
     })
     stub.restore_all()
@@ -63,7 +64,7 @@ describe("MountPoint.list_active", function()
   it("prefers findmnt output when findmnt is available", function()
     local MountPoint = with_mounts({
       findmnt_available = true,
-      findmnt_output = "deploy@example.com:/srv/app " .. BASE_DIR .. "/example\n",
+      findmnt_output = "deploy@example.com:/srv/app fuse.sshfs " .. BASE_DIR .. "/example\n",
       mount_output = "should-not-be-read on /elsewhere type fuse.sshfs (rw)",
     })
 

--- a/tests/sshfs_options_spec.lua
+++ b/tests/sshfs_options_spec.lua
@@ -1,0 +1,182 @@
+-- tests/sshfs_options_spec.lua
+-- SSHFS directory-cache option translation for 2.x implementations (fuse-t)
+--
+-- The option table is private, so these tests drive the real mount path with a
+-- faked SSH module and capture the sshfs command that gets executed.
+
+--- Run a mount and return the options from the resulting sshfs command
+--- @param opts table {version_stdout, version_code, version_error, sshfs_options}
+--- @return table options Map of sshfs option name to value (true for bare flags)
+--- @return table notifications Captured vim.notify calls
+local function mount_and_capture_options(opts)
+  stub.reload()
+  require("sshfs.config").setup({
+    connections = { sshfs_options = opts.sshfs_options, socket_dir = "/home/tester/.ssh/sockets" },
+  })
+
+  -- The real SSH module would open sockets; only the two entry points the mount
+  -- path uses are needed here.
+  package.loaded["sshfs.lib.ssh"] = {
+    try_batch_connect = function(_, callback)
+      callback(true, 0, nil)
+    end,
+    build_command_string = function()
+      return "ssh"
+    end,
+  }
+
+  local notifications = stub.notifications()
+  -- Run scheduled callbacks inline so the test stays synchronous.
+  stub.set("schedule", function(fn)
+    fn()
+  end)
+
+  local sshfs_command = nil
+  stub.set("system", function(cmd, _, callback)
+    if cmd[1] == "sshfs" and cmd[2] == "--version" then
+      if opts.version_error then error("sshfs is not executable") end
+      return {
+        wait = function()
+          return { code = opts.version_code or 0, stdout = opts.version_stdout or "", stderr = "" }
+        end,
+      }
+    end
+
+    sshfs_command = cmd
+    if callback then callback({ code = 0, stdout = "", stderr = "" }) end
+    return {
+      wait = function()
+        return { code = 0, stdout = "", stderr = "" }
+      end,
+    }
+  end)
+
+  require("sshfs.lib.sshfs").authenticate_and_mount(
+    { name = "example.com" },
+    "/Users/tester/mnt/example",
+    "/srv/app",
+    function() end
+  )
+  stub.restore_all()
+
+  local options = {}
+  if sshfs_command then
+    for index, argument in ipairs(sshfs_command) do
+      if argument == "-o" then
+        for _, option in ipairs(vim.split(sshfs_command[index + 1], ",", { plain = true })) do
+          local key, value = option:match("^([^=]+)=(.*)$")
+          if key then
+            options[key] = value
+          else
+            options[option] = true
+          end
+        end
+      end
+    end
+  end
+
+  return options, notifications
+end
+
+describe("SSHFS 3.x option handling", function()
+  it("leaves directory cache options untouched", function()
+    local options = mount_and_capture_options({
+      version_stdout = "SSHFS version 3.7.3",
+      sshfs_options = { dir_cache = "yes", dcache_timeout = 300, dcache_max_size = 10000 },
+    })
+
+    expect.eq(options.dir_cache, "yes")
+    expect.eq(options.dcache_timeout, "300")
+    expect.eq(options.dcache_max_size, "10000")
+    expect.is_nil(options.cache)
+    expect.is_nil(options.cache_timeout)
+    expect.is_nil(options.cache_max_size)
+  end)
+end)
+
+describe("SSHFS 2.x option translation", function()
+  it("translates the 3.x directory cache names", function()
+    local options = mount_and_capture_options({
+      version_stdout = "SSHFS version 2.10",
+      sshfs_options = { dir_cache = "yes", dcache_timeout = 300, dcache_max_size = 10000 },
+    })
+
+    expect.eq(options.cache, "yes")
+    expect.eq(options.cache_timeout, "300")
+    expect.eq(options.cache_max_size, "10000")
+  end)
+
+  it("removes the untranslated 3.x names", function()
+    local options = mount_and_capture_options({
+      version_stdout = "SSHFS version 2.10",
+      sshfs_options = { dir_cache = "yes", dcache_timeout = 300, dcache_max_size = 10000 },
+    })
+
+    expect.is_nil(options.dir_cache, "sshfs 2.x rejects unknown options")
+    expect.is_nil(options.dcache_timeout)
+    expect.is_nil(options.dcache_max_size)
+  end)
+
+  it("keeps unrelated options unchanged", function()
+    local options = mount_and_capture_options({
+      version_stdout = "SSHFS version 2.10",
+      sshfs_options = { reconnect = true, ConnectTimeout = 5, dir_cache = "yes" },
+    })
+
+    expect.eq(options.reconnect, true)
+    expect.eq(options.ConnectTimeout, "5")
+  end)
+
+  it("prefers an explicitly configured 2.x value over the translated one", function()
+    local options = mount_and_capture_options({
+      version_stdout = "SSHFS version 2.10",
+      sshfs_options = { dir_cache = "yes", cache = "no", dcache_timeout = 300, cache_timeout = 60 },
+    })
+
+    expect.eq(options.cache, "no", "the explicit 2.x value wins")
+    expect.eq(options.cache_timeout, "60")
+    expect.is_nil(options.dir_cache, "the translated name is still dropped")
+    expect.is_nil(options.dcache_timeout)
+  end)
+end)
+
+describe("SSHFS version detection failures", function()
+  it("retains configured options when the version cannot be parsed", function()
+    local options, notifications = mount_and_capture_options({
+      version_stdout = "some unrecognized banner",
+      sshfs_options = { dir_cache = "yes", dcache_timeout = 300 },
+    })
+
+    expect.eq(options.dir_cache, "yes")
+    expect.eq(options.dcache_timeout, "300")
+
+    local warned = false
+    for _, notification in ipairs(notifications) do
+      if type(notification.message) == "string" and notification.message:find("SSHFS version", 1, true) then
+        warned = true
+      end
+    end
+    expect.truthy(warned, "an unparseable version must warn rather than silently assume 3.x names")
+  end)
+
+  it("does not raise when the version probe itself fails", function()
+    expect.no_error(function()
+      mount_and_capture_options({
+        version_error = true,
+        sshfs_options = { dir_cache = "yes" },
+      })
+    end)
+  end)
+
+  it("does not raise when the version probe exits non-zero", function()
+    local options = expect.no_error(function()
+      return mount_and_capture_options({
+        version_code = 1,
+        version_stdout = "SSHFS version 2.10",
+        sshfs_options = { dir_cache = "yes" },
+      })
+    end)
+
+    expect.eq(options.cache, "yes", "a version reported on a non-zero exit is still usable")
+  end)
+end)

--- a/tests/unmount_spec.lua
+++ b/tests/unmount_spec.lua
@@ -1,0 +1,147 @@
+-- tests/unmount_spec.lua
+-- Unmount escalation and exit-hook registration
+--
+-- fuse-t cleanup has to finish before Neovim tears down, so unmounting runs
+-- synchronously and the exit hook moved to VimLeavePre.
+
+--- Run MountPoint.unmount against stubbed unmount tools
+--- @param opts table {available, succeeds_on} available command names and the
+---   first command string that should exit 0
+--- @return boolean result, table attempts, boolean waited_synchronously
+local function unmount_with(opts)
+  stub.reload()
+  require("sshfs.config").setup({})
+
+  stub.executable(opts.available)
+  stub.set("fn.delete", function()
+    return 0
+  end)
+
+  local attempts = {}
+  local waited_synchronously = false
+  stub.set("system", function(cmd)
+    table.insert(attempts, table.concat(cmd, " "))
+    return {
+      wait = function(_, timeout)
+        waited_synchronously = timeout ~= nil
+        local code = (table.concat(cmd, " ") == opts.succeeds_on) and 0 or 1
+        return { code = code, stdout = "", stderr = "" }
+      end,
+    }
+  end)
+
+  local result = require("sshfs.lib.mount_point").unmount("/Users/tester/mnt/host")
+  stub.restore_all()
+
+  return result, attempts, waited_synchronously
+end
+
+describe("MountPoint.unmount", function()
+  it("unmounts synchronously with a timeout rather than a background job", function()
+    local result, _, waited_synchronously = unmount_with({
+      available = { "umount" },
+      succeeds_on = "umount /Users/tester/mnt/host",
+    })
+
+    expect.truthy(result)
+    expect.truthy(waited_synchronously, "cleanup must complete before Neovim exits")
+  end)
+
+  it("prefers fusermount before falling back to umount", function()
+    local result, attempts = unmount_with({
+      available = { "fusermount", "umount" },
+      succeeds_on = "fusermount -u /Users/tester/mnt/host",
+    })
+
+    expect.truthy(result)
+    expect.eq(attempts, { "fusermount -u /Users/tester/mnt/host" })
+  end)
+
+  it("escalates clean, then lazy, then force", function()
+    local _, attempts = unmount_with({
+      available = { "umount", "diskutil" },
+      succeeds_on = "umount -f /Users/tester/mnt/host",
+    })
+
+    expect.eq(attempts, {
+      "umount /Users/tester/mnt/host",
+      "diskutil unmount /Users/tester/mnt/host",
+      "umount -l /Users/tester/mnt/host",
+      "diskutil unmount force /Users/tester/mnt/host",
+      "umount -f /Users/tester/mnt/host",
+    }, "a clean unmount is attempted before lazy, and lazy before force")
+  end)
+
+  it("uses diskutil where it is the only available tool", function()
+    local result, attempts = unmount_with({
+      available = { "diskutil" },
+      succeeds_on = "diskutil unmount /Users/tester/mnt/host",
+    })
+
+    expect.truthy(result)
+    expect.eq(attempts, { "diskutil unmount /Users/tester/mnt/host" })
+  end)
+
+  it("skips tools that are not installed", function()
+    local _, attempts = unmount_with({
+      available = { "umount" },
+      succeeds_on = "never-succeeds",
+    })
+
+    for _, attempt in ipairs(attempts) do
+      expect.falsy(attempt:find("fusermount", 1, true), "fusermount is absent and must not be invoked")
+      expect.falsy(attempt:find("diskutil", 1, true), "diskutil is absent and must not be invoked")
+    end
+  end)
+
+  it("reports failure when every strategy fails", function()
+    local result = unmount_with({ available = { "umount" }, succeeds_on = "never-succeeds" })
+    expect.falsy(result)
+  end)
+
+  it("reports failure when no unmount tool is installed", function()
+    local result, attempts = unmount_with({ available = {}, succeeds_on = "never-succeeds" })
+
+    expect.falsy(result)
+    expect.eq(attempts, {})
+  end)
+end)
+
+describe("automatic unmount on exit", function()
+  --- Capture the autocommand events sshfs.nvim registers during setup
+  local function registered_events(hooks)
+    stub.reload()
+    local events = {}
+    stub.set("api.nvim_create_autocmd", function(event, definition)
+      table.insert(events, { event = event, group = definition.group, desc = definition.desc })
+    end)
+    stub.set("fn.executable", function()
+      return 1
+    end)
+    stub.notifications()
+
+    require("sshfs").setup({ hooks = hooks })
+    stub.restore_all()
+
+    return events
+  end
+
+  it("registers cleanup on VimLeavePre so the event loop is still running", function()
+    local events = registered_events({ on_exit = { auto_unmount = true } })
+
+    local found = false
+    for _, entry in ipairs(events) do
+      if entry.event == "VimLeavePre" then found = true end
+      expect.falsy(entry.event == "VimLeave", "VimLeave runs too late for synchronous unmounting")
+    end
+    expect.truthy(found, "auto_unmount must register a VimLeavePre autocommand")
+  end)
+
+  it("registers no exit hook when auto_unmount is disabled", function()
+    local events = registered_events({ on_exit = { auto_unmount = false } })
+
+    for _, entry in ipairs(events) do
+      expect.falsy(entry.event == "VimLeavePre", "no exit hook is expected when auto_unmount is off")
+    end
+  end)
+end)


### PR DESCRIPTION
## Summary

Addresses #19 by adding compatibility for fuse-t's NFS-backed SSHFS mounts and its SSHFS 2.9 option names.

- detect `fuse-t:/... (nfs, ...)` mounts in the system mount table
- represent fuse-t mounts with `remote_metadata_available = false` when the original SSH host/path cannot be recovered
- fall back to mounted-path find/grep instead of attempting remote SSH operations with inferred metadata
- apply the same fallback to `hooks.on_mount.auto_run = "live_find"` / `"live_grep"`
- refuse SSH terminal actions cleanly when remote host metadata is unavailable rather than attempting SSH with display-only fallback metadata
- detect the installed SSHFS major version and translate the existing 3.x cache configuration to 2.x names when needed
  - `dir_cache` → `cache`
  - `dcache_timeout` → `cache_timeout`
  - `dcache_max_size` → `cache_max_size`
- preserve explicitly configured 2.x option values over translated values
- warn once when SSHFS version detection fails instead of silently assuming 3.x names
- move automatic cleanup from `VimLeave` to `VimLeavePre`
- run unmount attempts synchronously so fuse-t cleanup completes before Neovim teardown
- document macFUSE and fuse-t as supported macOS options

## Architecture

System mount state remains authoritative for whether a mount exists. The existing lockfile remains responsible only for tracking Neovim process ownership/reference counting; this avoids conflating mount discovery with process coordination.

fuse-t's NFS mount table does not preserve the original SSH remote specification. Rather than inventing authoritative host/path data or introducing a persistent mount registry in this compatibility fix, active fuse-t mounts expose that limitation through `remote_metadata_available = false`. Operations with a mounted-filesystem equivalent fall back to the mounted path; SSH-terminal actions refuse cleanly because they require a real remote host.

## Testing

Automated regression coverage is included, on top of the shared harness from #25. Run it with `make test`.

- fuse-t mount detection through both `mount` and `findmnt`, alongside Linux `fuse.sshfs` and macFUSE output
- fuse-t mounts expose `remote_metadata_available = false`, keep `remote_path` unset rather than inventing `/`, and do not error on a missing remote spec
- unrelated NFS mounts under the base directory are excluded
- live find/grep and the `on_mount` `auto_run` presets fall back to mounted-path operations without remote metadata
- SSH terminal actions refuse rather than dialing the mount directory name as a host
- SSHFS 3.x options stay unchanged; 2.x translates `dir_cache`/`dcache_timeout`/`dcache_max_size`, with explicit 2.x values winning
- version probe failures (unparseable, non-zero exit, missing binary) warn once and never raise
- synchronous unmounting with its clean, lazy and force escalation order
- `VimLeavePre` registration for the exit hook

This remains a draft pending validation on real hardware with `fuse-t` + `fuse-t-sshfs`, which the unit suite deliberately does not simulate.

Closes #19
