### PR TITLE
test: add automated test framework and CI foundation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Neovim
+        uses: rhysd/action-setup-vim@v1
+        with:
+          neovim: true
+          version: stable
+
+      - name: Run tests
+        run: nvim -l tests/run.lua
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check formatting
+        uses: JohnnyMorganz/stylua-action@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version: latest
+          args: --check lua/ tests/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+.PHONY: test lint format
+
+# Run the unit test suite. Pass PATTERN=<substring> to run a subset:
+#   make test PATTERN=mount_point
+test:
+	nvim -l tests/run.lua $(PATTERN)
+
+lint:
+	stylua --check lua/ tests/
+
+format:
+	stylua lua/ tests/

--- a/README.md
+++ b/README.md
@@ -342,3 +342,13 @@ Auth flow: keys first, then floating terminal for passphrases/passwords/2FA; Con
 - **Configure `global_paths`** with common directories (`/var/www`, `/var/log`, `~/.config`) to have them available across all hosts
 - **Configure `host_paths`** for frequently-used hosts to skip path selection
 - **Set `preferred_picker` for local/remote pickers** to force specific file picker(s) instead of auto-detection
+
+## 🧪 Development
+
+Run the unit test suite with:
+
+```sh
+make test
+```
+
+Tests run in headless Neovim with no external dependencies and never contact a real SSH server or mount table. See [`tests/README.md`](tests/README.md) for the harness, the available stubs, and how to add coverage. CI runs the suite and `stylua --check` on every pull request.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,55 @@
+# Tests
+
+Unit tests for sshfs.nvim. They run inside headless Neovim, use no external dependencies, and never contact a real SSH server or mount table.
+
+## Running
+
+```sh
+make test                      # everything
+make test PATTERN=mount_point  # only spec files whose path contains the pattern
+nvim -l tests/run.lua          # same as `make test`
+```
+
+The runner exits non-zero when any case fails, so it can gate CI. `.github/workflows/test.yml` runs the suite and `stylua --check` on every pull request.
+
+## Layout
+
+| File | Purpose |
+| --- | --- |
+| `harness.lua` | `describe`/`it` registry, assertions, result reporting |
+| `stub.lua` | Replaces the system-facing calls and restores them afterwards |
+| `run.lua` | Entry point: discovers `tests/*_spec.lua` and exits with the result |
+| `*_spec.lua` | One spec file per module under test |
+
+## Writing a test
+
+Spec files are plain Lua. The runner exposes `describe`, `it`, `expect`, and `stub` as globals, so no requires are needed.
+
+```lua
+describe("MountPoint.list_active", function()
+  it("ignores mounts outside the configured base directory", function()
+    stub.reload()
+    require("sshfs.config").setup({ mounts = { base_dir = "/home/tester/mnt" } })
+    stub.executable({})
+    stub.system(function()
+      return "deploy@example.com:/srv/app on /somewhere/else type fuse.sshfs (rw)", 0
+    end)
+
+    expect.eq(require("sshfs.lib.mount_point").list_active(), {})
+    stub.restore_all()
+  end)
+end)
+```
+
+### Assertions
+
+`expect.eq` (deep equality), `expect.truthy`, `expect.falsy`, `expect.is_nil`, `expect.contains` (plain substring), `expect.errors`, `expect.no_error`. Each takes an optional trailing context string that is shown on failure.
+
+### Stubs
+
+`stub.system(handler)` replaces `vim.fn.system` and the `v:shell_error` it reports; the handler returns `output, code`. `stub.vim_system(handler)` replaces `vim.system`, supporting both the async-callback and `:wait()` call styles, and returns the list of commands it received. `stub.executable(names)` controls `vim.fn.executable`. `stub.notifications()` captures `vim.notify` calls instead of printing them. `stub.set(path, value)` replaces any other field under `vim`.
+
+Two rules matter:
+
+- Call `stub.restore_all()` at the end of a case that stubbed anything.
+- Call `stub.reload()` before requiring a plugin module when the test depends on fresh module state. Several modules memoize (configuration, SSHFS version detection), so a stale load will leak state between cases.

--- a/tests/README.md
+++ b/tests/README.md
@@ -43,7 +43,7 @@ end)
 
 ### Assertions
 
-`expect.eq` (deep equality), `expect.truthy`, `expect.falsy`, `expect.is_nil`, `expect.contains` (plain substring), `expect.errors`, `expect.no_error`. Each takes an optional trailing context string that is shown on failure.
+`expect.eq` (deep equality), `expect.truthy`, `expect.falsy`, `expect.is_nil`, `expect.contains` (plain substring), `expect.errors`, `expect.no_error` (which forwards every value the call returned). Each takes an optional trailing context string that is shown on failure.
 
 ### Stubs
 

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -1,0 +1,98 @@
+-- tests/config_spec.lua
+-- Configuration merging, accessors, and deprecation shims
+
+local function load_config(user_config)
+  stub.reload()
+  local Config = require("sshfs.config")
+  Config.setup(user_config)
+  return Config
+end
+
+describe("Config.setup", function()
+  it("keeps defaults the user did not override", function()
+    local Config = load_config({ mounts = { base_dir = "/custom/mnt" } })
+    local opts = Config.get()
+
+    expect.eq(opts.mounts.base_dir, "/custom/mnt")
+    expect.eq(opts.connections.sshfs_options.reconnect, true)
+    expect.eq(opts.connections.sshfs_options.ConnectTimeout, 5)
+  end)
+
+  it("merges nested tables instead of replacing them", function()
+    local Config = load_config({ connections = { sshfs_options = { ConnectTimeout = 30 } } })
+    local options = Config.get().connections.sshfs_options
+
+    expect.eq(options.ConnectTimeout, 30, "the overridden value wins")
+    expect.eq(options.compression, "yes", "sibling defaults survive the merge")
+  end)
+
+  it("accepts no user configuration at all", function()
+    local Config = load_config(nil)
+    expect.truthy(Config.get().mounts.base_dir)
+  end)
+end)
+
+describe("Config accessors", function()
+  it("returns the configured mount base directory", function()
+    local Config = load_config({ mounts = { base_dir = "/custom/mnt" } })
+    expect.eq(Config.get_base_dir(), "/custom/mnt")
+  end)
+
+  it("returns the configured socket directory", function()
+    local Config = load_config({ connections = { socket_dir = "/custom/sockets" } })
+    expect.eq(Config.get_socket_dir(), "/custom/sockets")
+  end)
+
+  it("builds ControlMaster options from the socket directory and persist window", function()
+    local Config = load_config({ connections = { socket_dir = "/custom/sockets", control_persist = "5m" } })
+
+    expect.eq(Config.get_control_master_options(), {
+      "ControlMaster=auto",
+      "ControlPath=/custom/sockets/%C",
+      "ControlPersist=5m",
+    })
+  end)
+end)
+
+describe("Config deprecations", function()
+  it("maps ui.file_picker onto ui.local_picker and warns", function()
+    stub.reload()
+    local notifications = stub.notifications()
+    local Config = require("sshfs.config")
+    Config.setup({ ui = { file_picker = { preferred_picker = "telescope" } } })
+    stub.restore_all()
+
+    expect.eq(Config.get().ui.local_picker.preferred_picker, "telescope")
+    expect.eq(#notifications, 1)
+    expect.contains(notifications[1].message, "ui.file_picker")
+  end)
+
+  it("maps mounts.unmount_on_exit onto hooks.on_exit.auto_unmount", function()
+    stub.reload()
+    stub.notifications()
+    local Config = require("sshfs.config")
+    Config.setup({ mounts = { unmount_on_exit = true } })
+    stub.restore_all()
+
+    expect.eq(Config.get().hooks.on_exit.auto_unmount, true)
+  end)
+
+  it("maps mounts.auto_change_dir_on_mount onto hooks.on_mount.auto_change_to_dir", function()
+    stub.reload()
+    stub.notifications()
+    local Config = require("sshfs.config")
+    Config.setup({ mounts = { auto_change_dir_on_mount = false } })
+    stub.restore_all()
+
+    expect.eq(Config.get().hooks.on_mount.auto_change_to_dir, false)
+  end)
+
+  it("stays quiet when no deprecated key is used", function()
+    stub.reload()
+    local notifications = stub.notifications()
+    require("sshfs.config").setup({ mounts = { base_dir = "/custom/mnt" } })
+    stub.restore_all()
+
+    expect.eq(#notifications, 0)
+  end)
+end)

--- a/tests/harness.lua
+++ b/tests/harness.lua
@@ -1,0 +1,165 @@
+-- tests/harness.lua
+-- Minimal dependency-free test harness for sshfs.nvim
+--
+-- Tests are plain Lua files that call describe/it and the expect helpers. The
+-- runner executes them inside headless Neovim so the real vim API is available
+-- and only the system-facing calls need stubbing.
+
+local Harness = {}
+
+local suites = {}
+local current_suite = nil
+
+--- Register a group of test cases
+--- @param name string Suite name
+--- @param fn function Function that registers cases with it()
+function Harness.describe(name, fn)
+  local suite = { name = name, cases = {} }
+  table.insert(suites, suite)
+
+  current_suite = suite
+  local ok, err = pcall(fn)
+  current_suite = nil
+
+  if not ok then
+    -- A suite that fails to register is reported as a single failing case so
+    -- the runner still exits non-zero instead of silently skipping it.
+    table.insert(suite.cases, {
+      name = "<suite registration>",
+      fn = function()
+        error(err, 0)
+      end,
+    })
+  end
+end
+
+--- Register a single test case
+--- @param name string Case name
+--- @param fn function Test body; failures are raised as errors
+function Harness.it(name, fn)
+  if not current_suite then error("it() called outside of describe()", 2) end
+  table.insert(current_suite.cases, { name = name, fn = fn })
+end
+
+local function render(value)
+  if type(value) == "string" then return string.format("%q", value) end
+  if type(value) == "table" then return vim.inspect(value) end
+  return tostring(value)
+end
+
+local function fail(message, level)
+  error(message, (level or 2) + 1)
+end
+
+Harness.expect = {}
+
+--- Assert deep equality, comparing tables by value
+function Harness.expect.eq(actual, expected, context)
+  if not vim.deep_equal(actual, expected) then
+    fail(
+      string.format("%sexpected %s\n     got %s", context and (context .. ": ") or "", render(expected), render(actual))
+    )
+  end
+end
+
+--- Assert a value is neither nil nor false
+function Harness.expect.truthy(value, context)
+  if not value then
+    fail(string.format("%sexpected a truthy value, got %s", context and (context .. ": ") or "", render(value)))
+  end
+end
+
+--- Assert a value is nil or false
+function Harness.expect.falsy(value, context)
+  if value then
+    fail(string.format("%sexpected a falsy value, got %s", context and (context .. ": ") or "", render(value)))
+  end
+end
+
+--- Assert a value is exactly nil (distinct from false)
+function Harness.expect.is_nil(value, context)
+  if value ~= nil then
+    fail(string.format("%sexpected nil, got %s", context and (context .. ": ") or "", render(value)))
+  end
+end
+
+--- Assert a string contains a plain substring
+function Harness.expect.contains(haystack, needle, context)
+  if type(haystack) ~= "string" or not haystack:find(needle, 1, true) then
+    fail(
+      string.format(
+        "%sexpected %s to contain %s",
+        context and (context .. ": ") or "",
+        render(haystack),
+        render(needle)
+      )
+    )
+  end
+end
+
+--- Assert a function raises, optionally matching a plain substring of the error
+function Harness.expect.errors(fn, needle, context)
+  local ok, err = pcall(fn)
+  if ok then fail(string.format("%sexpected the call to raise an error", context and (context .. ": ") or "")) end
+  if needle then Harness.expect.contains(tostring(err), needle, context) end
+end
+
+--- Assert a function does not raise, returning its first result
+function Harness.expect.no_error(fn, context)
+  local ok, result = pcall(fn)
+  if not ok then
+    fail(string.format("%sexpected no error, got %s", context and (context .. ": ") or "", tostring(result)))
+  end
+  return result
+end
+
+--- Run every registered suite and report results
+--- @return number exit_code 0 when all cases pass
+function Harness.run()
+  -- io.write keeps line breaks deterministic; print() interleaves oddly under `nvim -l`
+  local function say(text)
+    io.write((text or "") .. "\n")
+  end
+
+  local passed, failed = 0, 0
+  local failures = {}
+
+  for _, suite in ipairs(suites) do
+    say(suite.name)
+    for _, case in ipairs(suite.cases) do
+      local ok, err = pcall(case.fn)
+      if ok then
+        passed = passed + 1
+        say("  ok   " .. case.name)
+      else
+        failed = failed + 1
+        say("  FAIL " .. case.name)
+        table.insert(failures, { name = suite.name .. " :: " .. case.name, err = tostring(err) })
+      end
+    end
+  end
+
+  say("")
+  if failed > 0 then
+    say("Failures:")
+    for _, failure in ipairs(failures) do
+      say("")
+      say("  " .. failure.name)
+      for line in failure.err:gmatch("[^\r\n]+") do
+        say("    " .. line)
+      end
+    end
+    say("")
+  end
+
+  say(string.format("%d passed, %d failed", passed, failed))
+  return failed == 0 and 0 or 1
+end
+
+--- Discard registered suites (used by the runner between files in-process)
+function Harness.reset()
+  suites = {}
+  current_suite = nil
+end
+
+return Harness

--- a/tests/harness.lua
+++ b/tests/harness.lua
@@ -104,13 +104,13 @@ function Harness.expect.errors(fn, needle, context)
   if needle then Harness.expect.contains(tostring(err), needle, context) end
 end
 
---- Assert a function does not raise, returning its first result
+--- Assert a function does not raise, returning every result it produced
 function Harness.expect.no_error(fn, context)
-  local ok, result = pcall(fn)
-  if not ok then
-    fail(string.format("%sexpected no error, got %s", context and (context .. ": ") or "", tostring(result)))
+  local results = { pcall(fn) }
+  if not results[1] then
+    fail(string.format("%sexpected no error, got %s", context and (context .. ": ") or "", tostring(results[2])))
   end
-  return result
+  return unpack(results, 2, #results)
 end
 
 --- Run every registered suite and report results

--- a/tests/mount_point_spec.lua
+++ b/tests/mount_point_spec.lua
@@ -1,0 +1,146 @@
+-- tests/mount_point_spec.lua
+-- Mount table parsing and mount directory handling
+
+local BASE_DIR = "/home/tester/mnt"
+
+--- Load MountPoint with a known base directory and a stubbed system mount table
+--- @param opts table {mount_output, findmnt_output, findmnt_available}
+local function with_mounts(opts)
+  stub.reload()
+  require("sshfs.config").setup({ mounts = { base_dir = BASE_DIR } })
+
+  stub.executable({ findmnt = opts.findmnt_available or false })
+  stub.system(function(cmd)
+    if type(cmd) == "table" and cmd[1] == "findmnt" then return opts.findmnt_output or "", opts.findmnt_code or 0 end
+    return opts.mount_output or "", 0
+  end)
+
+  return require("sshfs.lib.mount_point")
+end
+
+describe("MountPoint.list_active", function()
+  it("parses Linux fuse.sshfs mount output", function()
+    local MountPoint = with_mounts({
+      mount_output = table.concat({
+        "proc on /proc type proc (rw,nosuid)",
+        "deploy@example.com:/srv/app on " .. BASE_DIR .. "/example type fuse.sshfs (rw,nosuid,nodev)",
+      }, "\n"),
+    })
+
+    expect.eq(MountPoint.list_active(), {
+      {
+        host = "example.com",
+        mount_path = BASE_DIR .. "/example",
+        remote_path = "/srv/app",
+      },
+    })
+    stub.restore_all()
+  end)
+
+  it("parses macFUSE mount output", function()
+    local MountPoint = with_mounts({
+      mount_output = "deploy@example.com:/srv/app on " .. BASE_DIR .. "/example (macfuse, nodev, nosuid)",
+    })
+
+    local mounts = MountPoint.list_active()
+    expect.eq(#mounts, 1)
+    expect.eq(mounts[1].host, "example.com")
+    expect.eq(mounts[1].remote_path, "/srv/app")
+    stub.restore_all()
+  end)
+
+  it("parses a remote spec without a user", function()
+    local MountPoint = with_mounts({
+      mount_output = "example.com:/srv/app on " .. BASE_DIR .. "/example type fuse.sshfs (rw)",
+    })
+
+    local mounts = MountPoint.list_active()
+    expect.eq(mounts[1].host, "example.com")
+    expect.eq(mounts[1].remote_path, "/srv/app")
+    stub.restore_all()
+  end)
+
+  it("prefers findmnt output when findmnt is available", function()
+    local MountPoint = with_mounts({
+      findmnt_available = true,
+      findmnt_output = "deploy@example.com:/srv/app " .. BASE_DIR .. "/example\n",
+      mount_output = "should-not-be-read on /elsewhere type fuse.sshfs (rw)",
+    })
+
+    local mounts = MountPoint.list_active()
+    expect.eq(#mounts, 1)
+    expect.eq(mounts[1].mount_path, BASE_DIR .. "/example")
+    stub.restore_all()
+  end)
+
+  it("ignores mounts outside the configured base directory", function()
+    local MountPoint = with_mounts({
+      mount_output = "deploy@example.com:/srv/app on /somewhere/else type fuse.sshfs (rw)",
+    })
+
+    expect.eq(MountPoint.list_active(), {})
+    stub.restore_all()
+  end)
+
+  it("ignores non-sshfs mount lines", function()
+    local MountPoint = with_mounts({
+      mount_output = table.concat({
+        "tmpfs on " .. BASE_DIR .. "/tmp type tmpfs (rw)",
+        "/dev/sda1 on " .. BASE_DIR .. "/disk type ext4 (rw)",
+      }, "\n"),
+    })
+
+    expect.eq(MountPoint.list_active(), {})
+    stub.restore_all()
+  end)
+
+  it("returns no mounts when the mount command fails", function()
+    stub.reload()
+    require("sshfs.config").setup({ mounts = { base_dir = BASE_DIR } })
+    stub.executable({})
+    stub.system(function()
+      return "", 1
+    end)
+
+    expect.eq(require("sshfs.lib.mount_point").list_active(), {})
+    stub.restore_all()
+  end)
+end)
+
+describe("MountPoint.format_label", function()
+  it("includes the remote path when it is meaningful", function()
+    stub.reload()
+    local MountPoint = require("sshfs.lib.mount_point")
+    expect.eq(MountPoint.format_label({ host = "example.com", remote_path = "/srv/app" }), "example.com: /srv/app")
+  end)
+
+  it("omits the remote path for root and empty paths", function()
+    stub.reload()
+    local MountPoint = require("sshfs.lib.mount_point")
+    expect.eq(MountPoint.format_label({ host = "example.com", remote_path = "/" }), "example.com")
+    expect.eq(MountPoint.format_label({ host = "example.com", remote_path = "" }), "example.com")
+    expect.eq(MountPoint.format_label({ host = "example.com" }), "example.com")
+  end)
+end)
+
+describe("MountPoint.get_or_create", function()
+  it("reports success for a directory that already exists", function()
+    stub.reload()
+    local MountPoint = require("sshfs.lib.mount_point")
+    local temp_dir = vim.fn.tempname()
+    vim.fn.mkdir(temp_dir, "p")
+
+    expect.truthy(MountPoint.get_or_create(temp_dir))
+    vim.fn.delete(temp_dir, "rf")
+  end)
+
+  it("creates a missing directory", function()
+    stub.reload()
+    local MountPoint = require("sshfs.lib.mount_point")
+    local temp_dir = vim.fn.tempname() .. "/nested/mount"
+
+    expect.truthy(MountPoint.get_or_create(temp_dir))
+    expect.eq(vim.fn.isdirectory(temp_dir), 1)
+    vim.fn.delete(vim.fn.fnamemodify(temp_dir, ":h:h"), "rf")
+  end)
+end)

--- a/tests/path_spec.lua
+++ b/tests/path_spec.lua
@@ -1,0 +1,34 @@
+-- tests/path_spec.lua
+-- Remote-to-local path mapping used by the picker integrations
+
+local function load_path()
+  stub.reload()
+  return require("sshfs.lib.path")
+end
+
+describe("Path.map_remote_to_relative", function()
+  it("strips an absolute remote base path", function()
+    local Path = load_path()
+    expect.eq(Path.map_remote_to_relative("/srv/app/lib/init.lua", "/srv/app"), "lib/init.lua")
+  end)
+
+  it("strips a leading ./ for relative searches", function()
+    local Path = load_path()
+    expect.eq(Path.map_remote_to_relative("./lib/init.lua", "."), "lib/init.lua")
+  end)
+
+  it("strips a leading slash when the base does not match", function()
+    local Path = load_path()
+    expect.eq(Path.map_remote_to_relative("/other/lib/init.lua", "/srv/app"), "other/lib/init.lua")
+  end)
+
+  it("returns the base path itself as an empty relative path", function()
+    local Path = load_path()
+    expect.eq(Path.map_remote_to_relative("/srv/app", "/srv/app"), "")
+  end)
+
+  it("leaves an already relative path untouched", function()
+    local Path = load_path()
+    expect.eq(Path.map_remote_to_relative("lib/init.lua", "."), "lib/init.lua")
+  end)
+end)

--- a/tests/run.lua
+++ b/tests/run.lua
@@ -1,0 +1,43 @@
+-- tests/run.lua
+-- Test entry point: `nvim -l tests/run.lua [pattern]`
+--
+-- Discovers tests/*_spec.lua, runs them in one headless Neovim instance, and
+-- exits non-zero when any case fails so CI can gate on it.
+
+local root = vim.fn.fnamemodify(debug.getinfo(1, "S").source:sub(2), ":p:h:h")
+vim.opt.runtimepath:prepend(root)
+package.path = root .. "/?.lua;" .. root .. "/?/init.lua;" .. package.path
+
+local Harness = require("tests.harness")
+local Stub = require("tests.stub")
+
+-- describe/it/expect are exposed as globals so spec files stay free of boilerplate
+_G.describe = Harness.describe
+_G.it = Harness.it
+_G.expect = Harness.expect
+_G.stub = Stub
+
+local pattern = arg and arg[1]
+local spec_files = vim.fn.globpath(root .. "/tests", "*_spec.lua", false, true)
+table.sort(spec_files)
+
+local loaded = 0
+for _, file in ipairs(spec_files) do
+  if not pattern or file:find(pattern, 1, true) then
+    loaded = loaded + 1
+    local chunk, err = loadfile(file)
+    if not chunk then error("could not load " .. file .. ": " .. tostring(err)) end
+    chunk()
+  end
+end
+
+if loaded == 0 then
+  print("no spec files matched" .. (pattern and (" pattern " .. pattern) or ""))
+  os.exit(1)
+end
+
+-- Every case restores its own stubs, but a case that fails mid-test may not, so
+-- the runner clears anything left behind before reporting.
+local exit_code = Harness.run()
+Stub.restore_all()
+os.exit(exit_code)

--- a/tests/ssh_config_spec.lua
+++ b/tests/ssh_config_spec.lua
@@ -1,0 +1,55 @@
+-- tests/ssh_config_spec.lua
+-- Ad-hoc host string parsing used by :SSHConnect and friends
+
+local function load_ssh_config()
+  stub.reload()
+  return require("sshfs.lib.ssh_config")
+end
+
+describe("SSHConfig.parse_host", function()
+  it("parses a bare host alias", function()
+    local host = load_ssh_config().parse_host("production")
+
+    expect.eq(host.name, "production")
+    expect.is_nil(host.user)
+    expect.is_nil(host.path)
+    expect.is_nil(host.port)
+  end)
+
+  it("parses user@host", function()
+    local host = load_ssh_config().parse_host("deploy@example.com")
+
+    expect.eq(host.name, "example.com")
+    expect.eq(host.user, "deploy")
+    expect.is_nil(host.path)
+  end)
+
+  it("parses user@host:path", function()
+    local host = load_ssh_config().parse_host("deploy@example.com:/srv/app")
+
+    expect.eq(host.name, "example.com")
+    expect.eq(host.user, "deploy")
+    expect.eq(host.path, "/srv/app")
+  end)
+
+  it("parses host:path without a user", function()
+    local host = load_ssh_config().parse_host("example.com:/srv/app")
+
+    expect.eq(host.name, "example.com")
+    expect.is_nil(host.user)
+    expect.eq(host.path, "/srv/app")
+  end)
+
+  it("extracts an explicit port and keeps it out of the host name", function()
+    local host = load_ssh_config().parse_host("deploy@example.com:/srv/app -p 2222")
+
+    expect.eq(host.port, "2222")
+    expect.eq(host.name, "example.com")
+    expect.eq(host.path, "/srv/app")
+  end)
+
+  it("treats an empty path as absent", function()
+    local host = load_ssh_config().parse_host("example.com:")
+    expect.is_nil(host.path)
+  end)
+end)

--- a/tests/ssh_spec.lua
+++ b/tests/ssh_spec.lua
@@ -1,0 +1,92 @@
+-- tests/ssh_spec.lua
+-- SSH command construction
+
+local SOCKET_DIR = "/home/tester/.ssh/sockets"
+local CONTROL_PATH = "ControlPath=" .. SOCKET_DIR .. "/%C"
+
+local function load_ssh()
+  stub.reload()
+  require("sshfs.config").setup({ connections = { socket_dir = SOCKET_DIR, control_persist = "10m" } })
+  return require("sshfs.lib.ssh")
+end
+
+describe("Ssh.build_command_string", function()
+  it("passes only the control path when reusing a socket", function()
+    local Ssh = load_ssh()
+    expect.eq(Ssh.build_command_string("socket"), "ssh -o " .. CONTROL_PATH)
+  end)
+
+  it("forces a master and disables prompts for batch connections", function()
+    local Ssh = load_ssh()
+    local command = Ssh.build_command_string("batch")
+
+    expect.contains(command, "ControlMaster=yes")
+    expect.contains(command, CONTROL_PATH)
+    expect.contains(command, "BatchMode=yes")
+  end)
+
+  it("uses an automatic master for interactive sessions", function()
+    local Ssh = load_ssh()
+    local command = Ssh.build_command_string(nil)
+
+    expect.contains(command, "ControlMaster=auto")
+    expect.contains(command, "ControlPersist=10m")
+    expect.falsy(command:find("BatchMode", 1, true), "interactive sessions must stay interactive")
+  end)
+end)
+
+describe("Ssh.build_command", function()
+  it("returns a command list rather than a shell string", function()
+    local Ssh = load_ssh()
+    local cmd = Ssh.build_command("example.com", nil)
+
+    expect.eq(cmd[1], "ssh")
+    expect.eq(cmd[#cmd], "example.com")
+  end)
+
+  it("requests a tty and a login shell when a remote path is given", function()
+    local Ssh = load_ssh()
+    local cmd = Ssh.build_command("example.com", "/srv/app")
+
+    expect.eq(cmd[#cmd - 1], "-t")
+    expect.eq(cmd[#cmd], "cd '/srv/app' && exec $SHELL -l")
+  end)
+
+  it("expands a bare tilde through the remote shell", function()
+    local Ssh = load_ssh()
+    local cmd = Ssh.build_command("example.com", "~")
+    expect.eq(cmd[#cmd], "cd ~ && exec $SHELL -l")
+  end)
+
+  it("expands the home prefix while quoting the remainder", function()
+    local Ssh = load_ssh()
+    local cmd = Ssh.build_command("example.com", "~/projects/app")
+    expect.eq(cmd[#cmd], "cd ~ && cd 'projects/app' && exec $SHELL -l")
+  end)
+
+  it("escapes single quotes in remote paths", function()
+    local Ssh = load_ssh()
+    local cmd = Ssh.build_command("example.com", "/srv/it's here")
+
+    expect.contains(cmd[#cmd], "'/srv/it'\\''s here'")
+  end)
+end)
+
+describe("Ssh.cleanup_control_master", function()
+  it("sends an exit control command for the host", function()
+    local Ssh = load_ssh()
+    local received = nil
+    stub.system(function(cmd)
+      received = cmd
+      return ""
+    end)
+
+    Ssh.cleanup_control_master("example.com")
+    stub.restore_all()
+
+    expect.eq(received[1], "ssh")
+    expect.eq(received[#received], "example.com")
+    expect.eq(received[#received - 2], "-O")
+    expect.eq(received[#received - 1], "exit")
+  end)
+end)

--- a/tests/stub.lua
+++ b/tests/stub.lua
@@ -1,0 +1,152 @@
+-- tests/stub.lua
+-- Stubbing helpers for the system-facing calls sshfs.nvim makes
+--
+-- Unit tests must never touch a real SSH server or mount table, so the few
+-- entry points that reach the operating system (vim.fn.system, vim.fn.executable,
+-- vim.system, vim.uv.fs_stat, vim.notify) are replaced per test and restored
+-- afterwards by Stub.restore_all().
+
+local Stub = {}
+
+local restorers = {}
+
+local function split_path(path)
+  local parts = {}
+  for part in path:gmatch("[^%.]+") do
+    table.insert(parts, part)
+  end
+  return parts
+end
+
+--- Replace a dotted field under `vim` (e.g. "fn.system") for the current test
+--- @param path string Dotted path relative to the vim table
+--- @param value any Replacement value
+function Stub.set(path, value)
+  local parts = split_path(path)
+  local target = vim
+  for index = 1, #parts - 1 do
+    target = target[parts[index]]
+  end
+
+  local key = parts[#parts]
+  local original = target[key]
+  target[key] = value
+  table.insert(restorers, function()
+    target[key] = original
+  end)
+end
+
+--- Replace vim.v so tests can control v:shell_error, which is read-only
+--- @param shell_error number Value reported to code that inspects vim.v.shell_error
+function Stub.shell_error(shell_error)
+  local original = vim.v
+  vim.v = setmetatable({ shell_error = shell_error }, { __index = original })
+  table.insert(restorers, function()
+    vim.v = original
+  end)
+end
+
+--- Stub vim.fn.system with a handler and set the resulting v:shell_error
+--- The handler receives the command (string or list) and returns output plus an
+--- optional exit code, defaulting to 0.
+--- @param handler function fun(cmd): string, number|nil
+function Stub.system(handler)
+  local shell_error = 0
+  Stub.set("fn.system", function(cmd)
+    local output, code = handler(cmd)
+    shell_error = code or 0
+    return output or ""
+  end)
+
+  local original = vim.v
+  vim.v = setmetatable({}, {
+    __index = function(_, key)
+      if key == "shell_error" then return shell_error end
+      return original[key]
+    end,
+  })
+  table.insert(restorers, function()
+    vim.v = original
+  end)
+end
+
+--- Stub vim.fn.executable from a set of available command names
+--- @param available table Map or list of command names that should report as present
+function Stub.executable(available)
+  local lookup = {}
+  if vim.islist(available) then
+    for _, name in ipairs(available) do
+      lookup[name] = true
+    end
+  else
+    lookup = available
+  end
+
+  Stub.set("fn.executable", function(name)
+    return lookup[name] and 1 or 0
+  end)
+end
+
+--- Build a vim.system replacement
+--- The handler receives the command list and returns a result table with code,
+--- stdout, and stderr. The stub supports both call styles used in the plugin:
+--- an async callback and a synchronous `:wait()` on the returned object.
+--- @param handler function fun(cmd): table
+--- @return table calls List of command lists the stub received
+function Stub.vim_system(handler)
+  local calls = {}
+
+  Stub.set("system", function(cmd, _, callback)
+    table.insert(calls, cmd)
+    local result = handler(cmd) or {}
+    result.code = result.code or 0
+    result.stdout = result.stdout or ""
+    result.stderr = result.stderr or ""
+
+    if callback then
+      callback(result)
+      return {
+        wait = function()
+          return result
+        end,
+      }
+    end
+
+    return {
+      wait = function()
+        return result
+      end,
+    }
+  end)
+
+  return calls
+end
+
+--- Capture vim.notify calls instead of printing them
+--- @return table notifications List of {message, level} tables
+function Stub.notifications()
+  local captured = {}
+  Stub.set("notify", function(message, level)
+    table.insert(captured, { message = message, level = level })
+  end)
+  return captured
+end
+
+--- Drop cached sshfs.nvim modules so per-module state is rebuilt
+--- Several modules memoize (SSHFS version detection, config options), so tests
+--- that exercise that state must start from a clean load.
+function Stub.reload()
+  for name in pairs(package.loaded) do
+    if name:match("^sshfs") then package.loaded[name] = nil end
+  end
+end
+
+--- Undo every stub applied since the last restore
+function Stub.restore_all()
+  for index = #restorers, 1, -1 do
+    restorers[index]()
+  end
+  restorers = {}
+end
+
+return Stub


### PR DESCRIPTION
## Summary

Implements #24: a lightweight, dependency-free test harness plus CI, so the open feature PRs have somewhere to put their regression coverage.

- adds `describe`/`it`, deep-equality and error assertions, and a result reporter
- adds a stub module for the system-facing calls (`vim.fn.system`, `vim.fn.executable`, `vim.system`, `vim.notify`), restored per case
- adds a runner exiting non-zero on failure: `nvim -l tests/run.lua`, wrapped as `make test`
- adds `make test PATTERN=<substring>` to run a subset
- runs the suite and `stylua --check` on every pull request
- documents the harness, stubs, and how to add coverage in `tests/README.md`

## Design

The harness runs inside headless Neovim via `nvim -l`, so the real `vim` API is available and only the handful of calls that reach the operating system need stubbing. That keeps the mocking surface small: a spec stubs the mount table or an SSH subprocess and calls the module directly.

No external dependency is introduced. Neovim is the only thing CI installs.

Two conventions keep cases isolated: `stub.restore_all()` undoes stubs at the end of a case, and `stub.reload()` clears cached `sshfs.*` modules so memoized state (configuration, SSHFS version detection) does not leak between cases.

## Baseline coverage

41 cases against behavior already on `main`:

- mount table parsing for Linux `fuse.sshfs`, macFUSE, and `findmnt` output, including non-sshfs lines, mounts outside the base directory, and a failing `mount` command
- mount directory creation
- SSH command construction: socket/batch/interactive option sets, tty and login shell handling, tilde expansion, single-quote escaping, ControlMaster teardown
- ad-hoc host string parsing (`user@host:path -p 2222` and its variants)
- configuration merging and all three deprecation shims
- remote-to-local path mapping

## Follow-up

Feature-specific coverage stays with each feature PR, as those PRs describe. Once this lands, #20, #21, #22, and #23 pick it up and add their own regression suites.

Closes #24